### PR TITLE
Fix arch linux dependencies install command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ obj/
 >>>>>>> 9990422359331f2330abfad091c9c755b5d21515
 
 \.vscode/
+
+\.idea/
+
+cmake-build-debug/

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ First, download the repository to your local machine.
 
 #### Linux
 As SFML will be built from sources, you will be required to have the SFML sources.
-Debian-based(eg. Lubuntu, Xubuntu, Ubuntu, ...): ``sudo apt-get install -y libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libxrandr-dev libfreetype6-dev libglew1.5-dev libjpeg8-dev libsndfile1-dev libopenal-dev libudev-dev libxcb-image0-dev libjpeg-dev libflac-dev``
-
-Arch Linux-based(eg. Manjaro): ``sudo pacman -S -Y libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libxrandr-dev libfreetype6-dev libglew1.5-dev libjpeg8-dev libsndfile1-dev libopenal-dev libudev-dev libxcb-image0-dev libjpeg-dev libflac-dev``
-
+##### Debian-based(eg. Lubuntu, Xubuntu, Ubuntu, ...)
+``sudo apt-get install -y libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libxrandr-dev libfreetype6-dev libglew1.5-dev libjpeg8-dev libsndfile1-dev libopenal-dev libudev-dev libxcb-image0-dev libjpeg-dev libflac-dev``
 The -y parameter works by automatically accepting the requests for approval.
+
+##### Arch Linux-based(eg. Manjaro)
+``sudo pacman -S libpthread-stubs libx11 libxrandr libjpeg libsndfile libudev0 libxcb mesa libxrandr freetype2 glew libjpeg6-turbo openal flac``
+
 
 Other distributions will follow. The dependency names are listed here:
 https://www.sfml-dev.org/tutorials/2.4/compile-with-cmake.php

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ As SFML will be built from sources, you will be required to have the SFML source
 The -y parameter works by automatically accepting the requests for approval.
 
 ##### Arch Linux-based(eg. Manjaro)
-``sudo pacman -S libpthread-stubs libx11 libxrandr libjpeg libsndfile libudev0 libxcb mesa libxrandr freetype2 glew libjpeg6-turbo openal flac``
+``sudo pacman -S libpthread-stubs libx11 libxrandr libjpeg libsndfile libudev0 libxcb mesa libxrandr freetype2 glew libjpeg-turbo openal flac``
 
 
 Other distributions will follow. The dependency names are listed here:

--- a/src/gameobject/GameObjectFactory.cpp
+++ b/src/gameobject/GameObjectFactory.cpp
@@ -39,23 +39,23 @@ void GameObjectFactory::createTemplate(const std::string& name)
 
         if (componentJSON["componentType"].get<std::string>() == "Test")
             gameObject->addComponent<TestComponent>(std::make_unique<TestComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "Renderer")
+        else if (componentJSON["componentType"].get<std::string>() == "Renderer")
             gameObject->addComponent<RendererComponent>(std::make_unique<RendererComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "Transform")
+        else if (componentJSON["componentType"].get<std::string>() == "Transform")
             gameObject->addComponent<TransformComponent>(std::make_unique<TransformComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "Player")
+        else if (componentJSON["componentType"].get<std::string>() == "Player")
             gameObject->addComponent<PlayerComponent>(std::make_unique<PlayerComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "Mouse")
+        else if (componentJSON["componentType"].get<std::string>() == "Mouse")
             gameObject->addComponent<MouseComponent>(std::make_unique<MouseComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "Camera")
+        else if (componentJSON["componentType"].get<std::string>() == "Camera")
             gameObject->addComponent<CameraComponent>(std::make_unique<CameraComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "Animation")
+        else if (componentJSON["componentType"].get<std::string>() == "Animation")
             gameObject->addComponent<AnimationComponent>(std::make_unique<AnimationComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "ColliderAABB")
+        else if (componentJSON["componentType"].get<std::string>() == "ColliderAABB")
             gameObject->addComponent<ColliderAABBComponent>(std::make_unique<ColliderAABBComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "RigidBody")
+        else if (componentJSON["componentType"].get<std::string>() == "RigidBody")
             gameObject->addComponent<RigidBodyComponent>(std::make_unique<RigidBodyComponent>(*gameObject, componentJSON));
-        if (componentJSON["componentType"].get<std::string>() == "FPS")
+        else if (componentJSON["componentType"].get<std::string>() == "FPS")
             gameObject->addComponent<FPSComponent>(std::make_unique<FPSComponent>(*gameObject, componentJSON));
     }
 


### PR DESCRIPTION
The previous command for installing the build and run dependencies on arch linux and it's derivatives, `sudo pacman -S -Y libpthread-stubs0-dev libgl1-mesa-dev libx11-dev libxrandr-dev libfreetype6-dev libglew1.5-dev libjpeg8-dev libsndfile1-dev libopenal-dev libudev-dev libxcb-image0-dev libjpeg-dev libflac-dev`, has multiple flaws in it. For one, it has an invalid flag, `-Y`, which does not exisit in pacman, and, perhaps the largest flaw, the packages it attempts to install, are invalid. They do not exist.
```
:: no results found for libpthread-stubs0-dev
:: no results found for libgl1-mesa-dev
:: no results found for libx11-dev
:: no results found for libxrandr-dev
:: no results found for libfreetype6-dev
:: no results found for libglew1.5-dev
:: no results found for libjpeg8-dev
:: no results found for libsndfile1-dev
:: no results found for libopenal-dev
:: no results found for libudev-dev
:: no results found for libxcb-image0-dev
:: no results found for libjpeg-dev
:: no results found for libflac-dev
```
The corrected command:
`sudo pacman -S libpthread-stubs libx11 libxrandr libjpeg libsndfile libudev0 libxcb mesa libxrandr freetype2 glew libjpeg-turbo openal flac`
With the correct packages:
```
libpthread-stubs
libx11
libxrandr
libjpeg
libsndfile
libudev0
libxcb
mesa
libxrandr
freetype2
glew
libjpeg-turbo
openal
flac
```